### PR TITLE
Modernize a fair amount of of the documentation

### DIFF
--- a/content/faq/out-of-memory-and-java-issues.md
+++ b/content/faq/out-of-memory-and-java-issues.md
@@ -19,9 +19,9 @@ You increase the memory allotment by editing the *pcgen.bet* file.
 -   Open the *pcgen.bat* file
 -   Find and change the following code:
     -   **From:**
-        `java -Dswing.aatext=true -Xms128m -Xmx256m -jar pcgen.jar`
+        `java -Xms128m -Xmx256m -jar pcgen.jar`
     -   **To:**
-        `java -Dswing.aatext=true -Xms256m -Xmx512m -jar pcgen.jar`
+        `java -Xms256m -Xmx512m -jar pcgen.jar`
 -   **Note:** `-Xms256` assigns starting memory for PCGen to 256Mb of
     RAM and should be enough memory for pcgen to run with lots of
     sources loaded.
@@ -85,17 +85,8 @@ What Java do I need?
 The following are the versions of Java required for PCGen (by PCGen
 version)
 
- PCGen 5.12.x and above 
-:   Java 1.5.x or Java 1.6.0\_01 (and above)
-
- PCGen 5.10.2 and below 
-:   Java 1.5.x
-
- PCGen 5.8.1 and below 
-:   Java 1.4.x
-
- PCGen 5.6.1 and below 
-:   Java 1.3.x
+ PCGen 6.x.x and above 
+:   Java 8 or above
 
 ------------------------------------------------------------------------
 
@@ -110,11 +101,9 @@ Go the command prompt and type:
 
 You should get some kind of a response like:
 
-`java version "1.5.0_06"`
-
-`Java(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_06-b05)`
-
-`Java HotSpot(TM) Client VM (build 1.5.0_06-b05, mixed mode, sharing)`
+`java version "1.8.0_112"
+`Java(TM) SE Runtime Environment (build 1.8.0_112-b16)
+`Java HotSpot(TM) 64-Bit Server VM (build 25.112-b16, mixed mode)
 
 #### For Windows Vista Users:
 
@@ -130,13 +119,13 @@ Open "Java Application Runtime Setting"
 
 Open "User"
 
-Click the Enabled button on any Java version other than 1.6.0\_00
+Click the Enabled button on any Java version other than 1.8.0\_00
 
 Open "System"
 
 Only have one in mine and its not selectable
 
-#### For Mac Users:
+#### For Unix/Mac Users:
 
 Open a terminal window and enter:
 
@@ -144,15 +133,9 @@ Open a terminal window and enter:
 
 You should get some kind of a response like:
 
-`java version "1.5.0_06"`
-
-`Java(TM) 2 Runtime Environment, Standard Edition (build 1.5.0_06-b05)`
-
-`Java HotSpot(TM) Client VM (build 1.5.0_06-b05, mixed mode, sharing)`
-
-#### For Unix Users:
-
-Refer to the Mac instructions.
+`java version "1.8.0_112"
+`Java(TM) SE Runtime Environment (build 1.8.0_112-b16)
+`Java HotSpot(TM) 64-Bit Server VM (build 25.112-b16, mixed mode)
 
 ------------------------------------------------------------------------
 
@@ -162,7 +145,7 @@ Miscelaneous Error Messages
  **Bad command or file name** 
 :   A common cause for this error is not having java installed. Go to
     <http://java.sun.com/> and download and install the latest java
-    1.5.x JRE. You'll then be able to run PCGen.
+    8 JRE. You'll then be able to run PCGen.
 
 ------------------------------------------------------------------------
 

--- a/content/faq/startup-install-issues.md
+++ b/content/faq/startup-install-issues.md
@@ -58,39 +58,27 @@ original_url = "/faq/startup-install-issues.html"
     Glad you asked, because for many of you the instructions failed
     didn't they? Well here's why.
 
-    Make sure that have the Java 2 v1.6.x or above Runtime Environment
+    Make sure that have the Java 8 or above Runtime Environment
     (or the SDK) installed on your machine. It's available from:
     <http://java.com/en/download/> .
-
-    Mac users should note that Apple does not, and will not, support
-    Java 2 v1.7.x or greater for Mac OSX 10.6.8 or earlier.
 
 5.  <span class="underline"> Will PCGen run on my machine? </span>
 
     That depends. The one thing that decides if you can run PCGen or
-    not, is whether you have at least JAVA 1.6+ installed. If you do,
+    not, is whether you have at least JAVA 8+ installed. If you do,
     then it should run. If not, it won't. It really is that simple.
 
     However, some might want to check here, so here is a small list:
 
       -------------------------- --------------------------------------------------------------------------------------------------------------
       **OS**                     **Does it Work?**
-      Mac OS 7.x - 9.x           No. (Actually, it might. As a work-around, you can install VirtualPC (or some such) and run PCGen in there.)
-      Mac OSX 10 to 10.4         No
-      Mac OSX 10.5+              Yes (Running Windows XP, Vista, or 7 on Boot Camp)
-      Mac OSX 10.5.2 to 10.6.8   Yes (64bit Only)
-      Mac OSX 10.7+              Yes (JRE 1.7+ required)
-      Win 98                     No
-      Win 98 SE                  No
-      Win NT                     No
-      Win 2000                   Yes (32bit Only)
+      Mac OSX 10+	         Yes
       Win XP                     Yes
       Win Vista                  Yes
       Unix                       Yes
       Linux                      Yes
+      FreeBSD                    Yes
       -------------------------- --------------------------------------------------------------------------------------------------------------
-
-    Not all of these configurations have been tested.
 
 6.  <span class="underline"> Mac OSX telling me "PCGen can't be opened
     because . . . " </span>

--- a/content/list/system/gamemode-miscinfo/weightpattern.md
+++ b/content/list/system/gamemode-miscinfo/weightpattern.md
@@ -30,8 +30,7 @@ Used in UNITSET lines to define the weight unit pattern. The 'pattern'
 string is a pattern for formatting the output of the value, so you can
 specify e.g. how many decimal digits are printed. The pattern follows
 the definition of the Java class DecimaFormat and can be found
-[here](http://java.sun.com/j2se/1.3/docs/api/java/text/DecimalFormat.html)
-.
+[here](https://docs.oracle.com/javase/8/docs/api/java/text/DecimalFormat.html).
 
 Example
 -------

--- a/content/outputsheet/tokens/misc.md
+++ b/content/outputsheet/tokens/misc.md
@@ -1057,8 +1057,8 @@ effect.
         -   "\_\_RP\_\_" as the substitute for "}"
         -   "\_\_PLUS\_\_" as the substitute for "+"
         -   Note: Help on regular expressions can be found at the [Java
-            Platform SE6
-            Pattern](http://docs.oracle.com/javase/6/docs/api/java/util/regex/Pattern.html) page.
+            Platform 
+            Pattern](https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html) page.
 -   `SENTENCE` , `SENTENCECASE` - Output the tag result in
     sentence case. e.g. The vitamins are in my fresh brussels sprouts
 -   `TITLE` , `TITLECASE` - Output the tag result in title case. e.g.


### PR DESCRIPTION
This removes some old references (anything pcgen 5.x or older) and
updates the docs to talk about Java 8 or above.

This PR isn't complete, but its a start.

We should also remove some other older untrue messages (e.g., advice to
use 256mb of RAM).

More generally there is a fair amount of duplicated information here
which we should remove and replace with pointers.