### PR TITLE
Improve git clone example in main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Markdown-formatted text is compiled using Hugo, an excellent "static site ge
  3. Download a copy ("clone") of the `pcgen-docs` repository to your computer.
       * i.e. to make a copy to C:/pcgen-docs/, you would do:
  
-        `git clone --recursive https://github.com/LiaungYip/pcgen-docs G:/pcgen-docs/`
+        `git clone --recursive https://github.com/PCGen/pcgen-docs.git C:/pcgen-docs/`
  
         Note the `--recursive` option is required to download the website theme, which is a "sub-module" of the main repository.
  


### PR DESCRIPTION
Couple of suggestions here:

- Replace `https://github.com/LiaungYip/pcgen-docs` URL in the instructions for the git clone
- Use `C:/pcgen-docs/` in the git clone example to be consistent with the instruction on the line (:18) above

Note: the diff is showing a change to line 49 but I have no idea where this comes from